### PR TITLE
chore(visualize): improve line chart for request count

### DIFF
--- a/pkg/monitoring/client.go
+++ b/pkg/monitoring/client.go
@@ -41,7 +41,7 @@ type TimeSeries []Point
 func (ts TimeSeries) String() string {
 	var s []string
 	for _, v := range ts {
-		s = append(s, fmt.Sprintf("t:%s:c:%v", v.Time.Format(time.TimeOnly), v.Val))
+		s = append(s, fmt.Sprintf("%v", v.Val))
 	}
 	return strings.Join(s, ",")
 }

--- a/pkg/slack/event_handler.go
+++ b/pkg/slack/event_handler.go
@@ -191,7 +191,7 @@ func (h *SlackEventHandler) list(ctx context.Context, channel, actionId string) 
 
 func (h *SlackEventHandler) getServiceMetrics(ctx context.Context, channelId, svcName string) error {
 	duration := 24 * time.Hour
-	aggregationPeriod := 30 * time.Minute
+	aggregationPeriod := 5 * time.Minute
 	now := time.Now().UTC()
 	endTime := now.Truncate(aggregationPeriod).Add(aggregationPeriod)
 

--- a/pkg/slack/event_handler.go
+++ b/pkg/slack/event_handler.go
@@ -191,7 +191,7 @@ func (h *SlackEventHandler) list(ctx context.Context, channel, actionId string) 
 
 func (h *SlackEventHandler) getServiceMetrics(ctx context.Context, channelId, svcName string) error {
 	duration := 24 * time.Hour
-	aggergationPeriod := 1 * time.Hour
+	aggergationPeriod := 5 * time.Minute
 	seriesMap, err := h.mClient.GetCloudRunServiceRequestCount(ctx, svcName, aggergationPeriod, duration)
 
 	if err != nil {

--- a/pkg/slack/event_handler.go
+++ b/pkg/slack/event_handler.go
@@ -191,7 +191,7 @@ func (h *SlackEventHandler) list(ctx context.Context, channel, actionId string) 
 
 func (h *SlackEventHandler) getServiceMetrics(ctx context.Context, channelId, svcName string) error {
 	duration := 24 * time.Hour
-	aggregationPeriod := 5 * time.Minute
+	aggregationPeriod := 30 * time.Minute
 	now := time.Now().UTC()
 	endTime := now.Truncate(aggregationPeriod).Add(aggregationPeriod)
 
@@ -236,7 +236,7 @@ func (h *SlackEventHandler) getServiceMetrics(ctx context.Context, channelId, sv
 	imgName := path.Join(h.tmpDir, fmt.Sprintf("%s-metrics.png", svcName))
 	log.Printf("imgName: %s\n", imgName)
 
-	fileSize, err := visualize.Visualize(imgName, startTime, endTime, seriesMap)
+	fileSize, err := visualize.Visualize("Request Count", imgName, startTime, endTime, aggregationPeriod, seriesMap)
 	if err != nil {
 		log.Println(err)
 		return nil

--- a/pkg/slack/event_handler.go
+++ b/pkg/slack/event_handler.go
@@ -191,8 +191,12 @@ func (h *SlackEventHandler) list(ctx context.Context, channel, actionId string) 
 
 func (h *SlackEventHandler) getServiceMetrics(ctx context.Context, channelId, svcName string) error {
 	duration := 24 * time.Hour
-	aggergationPeriod := 5 * time.Minute
-	seriesMap, err := h.mClient.GetCloudRunServiceRequestCount(ctx, svcName, aggergationPeriod, duration)
+	aggregationPeriod := 5 * time.Minute
+	now := time.Now().UTC()
+	endTime := now.Truncate(aggregationPeriod).Add(aggregationPeriod)
+
+	startTime := endTime.Add(-1 * duration).UTC()
+	seriesMap, err := h.mClient.GetCloudRunServiceRequestCount(ctx, svcName, aggregationPeriod, startTime, endTime)
 
 	if err != nil {
 		_, _, err := h.client.PostMessageContext(ctx, channelId, slack.MsgOptionText("Failed to get request: "+err.Error(), false))
@@ -232,7 +236,7 @@ func (h *SlackEventHandler) getServiceMetrics(ctx context.Context, channelId, sv
 	imgName := path.Join(h.tmpDir, fmt.Sprintf("%s-metrics.png", svcName))
 	log.Printf("imgName: %s\n", imgName)
 
-	fileSize, err := visualize.Visualize(imgName, seriesMap)
+	fileSize, err := visualize.Visualize(imgName, startTime, endTime, seriesMap)
 	if err != nil {
 		log.Println(err)
 		return nil

--- a/pkg/visualize/visualize.go
+++ b/pkg/visualize/visualize.go
@@ -1,24 +1,42 @@
 package visualize
 
 import (
+	"log"
+	"math/rand"
 	"os"
 	"time"
 
 	"github.com/nakamasato/cloud-run-slack-bot/pkg/monitoring"
 	"github.com/wcharczuk/go-chart/v2"
+	"github.com/wcharczuk/go-chart/v2/drawing"
 )
+
+var predefinedColorMap = map[string]drawing.Color{
+	"2xx": chart.ColorAlternateGreen,
+	"4xx": chart.ColorAlternateYellow,
+	"5xx": chart.ColorRed,
+}
 
 // Visualize draw a line chart and export to a file.
 // Currently only supports hourly data for recent 24 hours.
-func Visualize(imgFile string, startTime, endTime time.Time, seriesMap *monitoring.TimeSeriesMap) (int64, error) {
+func Visualize(title, imgFile string, startTime, endTime time.Time, interval time.Duration, seriesMap *monitoring.TimeSeriesMap) (int64, error) {
 
 	series := []chart.Series{}
 	i := 0
 	for name, ts := range *seriesMap {
-		series = append(series, makeChartTimeSeries(name, startTime, endTime, time.Hour, &ts))
+		series = append(series, makeChartTimeSeries(i, name, startTime, endTime, interval, &ts))
 		i++
 	}
+	// ticks := []chart.Tick{}
+	// for t := startTime.Truncate(time.Hour); t.Before(endTime); t = t.Add(time.Hour) {
+	// 	ticks = append(ticks, chart.Tick{Value: float64(t.Unix()), Label: t.Format("15")})
+	// }
 	graph := chart.Chart{
+		Title: title,
+		// XAxis: chart.XAxis{
+		// 	Name:  "Time",
+		// 	Ticks: ticks,
+		// },
 		Series: series,
 	}
 
@@ -38,9 +56,17 @@ func Visualize(imgFile string, startTime, endTime time.Time, seriesMap *monitori
 	return stat.Size(), nil
 }
 
-func makeChartTimeSeries(name string, startTime, endTime time.Time, interval time.Duration, timeSeries *monitoring.TimeSeries) *chart.TimeSeries {
+func makeChartTimeSeries(i int, name string, startTime, endTime time.Time, interval time.Duration, timeSeries *monitoring.TimeSeries) *chart.TimeSeries {
+	color, ok := predefinedColorMap[name]
+	if !ok {
+		color = chart.GetDefaultColor(i)
+	}
 	cTs := chart.TimeSeries{
 		Name: name,
+		Style: chart.Style{
+			StrokeColor: color.WithAlpha(64),
+			FillColor:   color.WithAlpha(64),
+		},
 	}
 	counter := map[time.Time]float64{}
 	for _, p := range *timeSeries {
@@ -50,16 +76,39 @@ func makeChartTimeSeries(name string, startTime, endTime time.Time, interval tim
 		cTs.XValues = append(cTs.XValues, t)
 		cTs.YValues = append(cTs.YValues, counter[t])
 	}
+	log.Printf("name: %s\nXValues(%d): %v\nYValues(%d): %v", name, len(cTs.XValues), cTs.XValues, len(cTs.YValues), cTs.YValues)
 	return &cTs
 }
 
 func VisualizeSample(imgFile string) error {
+	durationInMin := 24 * 60
+	intervalInMin := 5
+
+	tsSuccess := chart.TimeSeries{
+		Name: "Success",
+		Style: chart.Style{
+			StrokeColor: chart.ColorAlternateGreen.WithAlpha(64),
+			FillColor:   chart.ColorAlternateGreen.WithAlpha(64),
+		},
+	}
+	tsError := chart.TimeSeries{
+		Name: "Error",
+		Style: chart.Style{
+			StrokeColor: chart.ColorRed.WithAlpha(64),
+			FillColor:   chart.ColorRed.WithAlpha(64),
+		},
+	}
+	for i := 0; i < durationInMin/intervalInMin; i++ {
+		tsSuccess.XValues = append(tsSuccess.XValues, time.Now().Add(time.Minute*time.Duration(intervalInMin*-i)))
+		tsSuccess.YValues = append(tsSuccess.YValues, rand.Float64()*100)
+		tsError.XValues = append(tsError.XValues, time.Now().Add(time.Minute*time.Duration(intervalInMin*-i)))
+		tsError.YValues = append(tsError.YValues, rand.Float64()*10)
+	}
+
 	graph := chart.Chart{
+		Title: "Sample Chart",
 		Series: []chart.Series{
-			chart.ContinuousSeries{
-				XValues: []float64{1.0, 2.0, 3.0, 4.0},
-				YValues: []float64{1.0, 2.0, 3.0, 4.0},
-			},
+			tsSuccess, tsError,
 		},
 	}
 

--- a/pkg/visualize/visualize.go
+++ b/pkg/visualize/visualize.go
@@ -1,8 +1,6 @@
 package visualize
 
 import (
-	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -13,23 +11,17 @@ import (
 // Visualize draw a line chart and export to a file.
 // Currently only supports hourly data for recent 24 hours.
 func Visualize(imgFile string, seriesMap *monitoring.TimeSeriesMap) (int64, error) {
-	xaxis := []float64{}
+	xaxis := []time.Time{}
 	yaxis := []float64{}
 	series := []chart.Series{}
-	now := time.Now()
+	// now := time.Now()
 	i := 0
 	for name, ts := range *seriesMap {
-		hour2val := map[int]float64{}
 		for _, p := range ts {
-			hour2val[p.Time.Hour()] += p.Val
+			xaxis = append(xaxis, p.Time)
+			yaxis = append(yaxis, p.Val)
 		}
-		for j := 23; j >=0; j-- {
-			t := now.Add(-time.Duration(j) * time.Hour)
-			log.Printf("name: %s, xaxis: %d, yaxis: %d\n", name, t.Hour(), hour2val[t.Hour()])
-			xaxis = append(xaxis, float64(t.Hour()))
-			yaxis = append(yaxis, hour2val[t.Hour()])
-		}
-		series = append(series, chart.ContinuousSeries{
+		series = append(series, chart.TimeSeries{
 			Name: name,
 			Style: chart.Style{
 				StrokeColor: chart.GetDefaultColor(i).WithAlpha(64),
@@ -39,16 +31,16 @@ func Visualize(imgFile string, seriesMap *monitoring.TimeSeriesMap) (int64, erro
 		})
 		i++
 	}
-	ticks := []chart.Tick{}
-	for i := 23; i >= 0; i-- {
-		t := now.Add(-time.Duration(i) * time.Hour)
-		ticks = append(ticks, chart.Tick{Value: float64(t.Hour()), Label: fmt.Sprintf("%d:00", t.Hour())})
-	}
+	// ticks := []chart.Tick{}
+	// for i := 23; i >= 0; i-- {
+	// 	t := now.Add(-time.Duration(i) * time.Hour)
+	// 	ticks = append(ticks, chart.Tick{Value: float64(t.Hour()), Label: fmt.Sprintf("%d:00", t.Hour())})
+	// }
 	graph := chart.Chart{
-		XAxis: chart.XAxis{
-			Name:  "Time",
-			Ticks: ticks,
-		},
+		// XAxis: chart.XAxis{
+		// 	Name:  "Time",
+		// 	Ticks: ticks,
+		// },
 		Series: series,
 	}
 

--- a/pkg/visualize/visualize.go
+++ b/pkg/visualize/visualize.go
@@ -2,6 +2,7 @@ package visualize
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -15,18 +16,29 @@ func Visualize(imgFile string, seriesMap *monitoring.TimeSeriesMap) (int64, erro
 	xaxis := []float64{}
 	yaxis := []float64{}
 	series := []chart.Series{}
+	now := time.Now()
+	i := 0
 	for name, ts := range *seriesMap {
+		hour2val := map[int]float64{}
 		for _, p := range ts {
-			xaxis = append(xaxis, float64(p.Time.Hour()))
-			yaxis = append(yaxis, p.Val)
+			hour2val[p.Time.Hour()] += p.Val
+		}
+		for j := 23; j >=0; j-- {
+			t := now.Add(-time.Duration(j) * time.Hour)
+			log.Printf("name: %s, xaxis: %d, yaxis: %d\n", name, t.Hour(), hour2val[t.Hour()])
+			xaxis = append(xaxis, float64(t.Hour()))
+			yaxis = append(yaxis, hour2val[t.Hour()])
 		}
 		series = append(series, chart.ContinuousSeries{
-			Name:    name,
+			Name: name,
+			Style: chart.Style{
+				StrokeColor: chart.GetDefaultColor(i).WithAlpha(64),
+			},
 			XValues: xaxis,
 			YValues: yaxis,
 		})
+		i++
 	}
-	now := time.Now()
 	ticks := []chart.Tick{}
 	for i := 23; i >= 0; i-- {
 		t := now.Add(-time.Duration(i) * time.Hour)

--- a/pkg/visualize/visualize_test.go
+++ b/pkg/visualize/visualize_test.go
@@ -1,0 +1,51 @@
+package visualize
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nakamasato/cloud-run-slack-bot/pkg/monitoring"
+	"github.com/wcharczuk/go-chart/v2"
+)
+
+func TestMakeChartTimeSeries(t *testing.T) {
+	tests := []struct {
+		name       string
+		startTime  time.Time
+		endTime    time.Time
+		interval   time.Duration
+		timeSeries *monitoring.TimeSeries
+		want       *chart.TimeSeries
+	}{
+		{
+			name:      "test",
+			startTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			endTime:   time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC),
+			interval:  10 * time.Minute,
+			timeSeries: &monitoring.TimeSeries{
+				{Time: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), Val: 1},
+				{Time: time.Date(2021, 1, 1, 0, 10, 0, 0, time.UTC), Val: 2},
+			},
+			want: &chart.TimeSeries{
+				Name: "test",
+				XValues: []time.Time{
+					time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2021, 1, 1, 0, 10, 0, 0, time.UTC),
+					time.Date(2021, 1, 1, 0, 20, 0, 0, time.UTC),
+					time.Date(2021, 1, 1, 0, 30, 0, 0, time.UTC),
+					time.Date(2021, 1, 1, 0, 40, 0, 0, time.UTC),
+					time.Date(2021, 1, 1, 0, 50, 0, 0, time.UTC),
+				},
+				YValues: []float64{1, 2, 0, 0, 0, 0},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := makeChartTimeSeries(tt.name, tt.startTime, tt.endTime, tt.interval, tt.timeSeries); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("XValues = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/visualize/visualize_test.go
+++ b/pkg/visualize/visualize_test.go
@@ -29,6 +29,9 @@ func TestMakeChartTimeSeries(t *testing.T) {
 			},
 			want: &chart.TimeSeries{
 				Name: "test",
+				Style: chart.Style{
+					StrokeColor: chart.GetDefaultColor(0).WithAlpha(64),
+				},
 				XValues: []time.Time{
 					time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					time.Date(2021, 1, 1, 0, 10, 0, 0, time.UTC),
@@ -43,7 +46,7 @@ func TestMakeChartTimeSeries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := makeChartTimeSeries(tt.name, tt.startTime, tt.endTime, tt.interval, tt.timeSeries); !reflect.DeepEqual(got, tt.want) {
+			if got := makeChartTimeSeries(0, tt.name, tt.startTime, tt.endTime, tt.interval, tt.timeSeries); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("XValues = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/visualize/visualize_test.go
+++ b/pkg/visualize/visualize_test.go
@@ -31,6 +31,7 @@ func TestMakeChartTimeSeries(t *testing.T) {
 				Name: "test",
 				Style: chart.Style{
 					StrokeColor: chart.GetDefaultColor(0).WithAlpha(64),
+					FillColor:   chart.GetDefaultColor(0).WithAlpha(64),
 				},
 				XValues: []time.Time{
 					time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),


### PR DESCRIPTION
# why

to make metrics clear and well-organized

# what

- set proper start time and end time based on duration
- add `makeChartTimeSeries` to visualize package with test
- remove latency-related logic temporarily

![image](https://github.com/nakamasato/cloud-run-slack-bot/assets/883228/53ca650f-fd03-4463-9c8b-534c9a8d7c0e)
