### PR TITLE
chore: add latest tags

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,4 +84,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build
-        run: ko build . --tags="${{ steps.set_config.outputs.TAGS }}" --bare
+        run: ko build . --tags="${{ steps.set_config.outputs.TAGS }},latest" --bare


### PR DESCRIPTION
# why

to enable to always use latest version

# what

add latest tag